### PR TITLE
feat: serve per-tenant favicon from training_provider.company_logo_url

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,10 @@ import { Html, Head, Main, NextScript } from 'next/document'
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link rel="icon" type="image/png" sizes="32x32" href="/api/favicon.png?size=32" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/api/favicon.png?size=16" />
+      </Head>
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
Wires the existing /api/favicon.png route into <link rel="icon"> in _document.tsx.

Each tenant's container reads its own DB and serves its own logo as favicon. Falls back to public/favicon.ico when no logo is configured.

Multi-tenant safe — Tertiary keeps Tertiary favicon, Chariot gets Chariot favicon, future tenants get the same plumbing for free.
