### PR TITLE
feat(tpgateway): run confirm & fetch on the server, streaming the sig…

### DIFF
--- a/components/admin/DirectApplicationViews.tsx
+++ b/components/admin/DirectApplicationViews.tsx
@@ -16,12 +16,7 @@ const TPG_JOB_KEY = 'lms.tpgConfirm.jobId';
  * inlines process.env.NODE_ENV at build time, so this is a compile-time constant
  * in the client bundle — the deployed build simply never contains the card.
  */
-const tpgAvailable =
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEXT_PUBLIC_TPG_SERVER_BROWSER === 'true';
 
-/** Where the operator's own LMS serves this page (npm run dev uses port 3000). */
-const LOCAL_LMS_TPG_URL = 'http://localhost:3000/?adminPage=uploadDirectApplication&view=admin';
 
 const inputClasses ="block w-full px-3 py-2 text-on-surface bg-white border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-500";
 
@@ -426,6 +421,21 @@ export const UploadDirectApplicationView: React.FC = () => {
         const iv = setInterval(() => setTpgNow(Date.now()), 1000);
         return () => clearInterval(iv);
     }, [tpgRunning, autoEnrolPolling]);
+
+    /** Forward a click or keystroke to the browser the server is driving. */
+    const sendTpgInput = async (input: { kind: 'click'; x: number; y: number } | { kind: 'type'; text: string } | { kind: 'key'; key: string }) => {
+        if (!tpgJobId) return;
+        try {
+            await fetch('/api/admin/tpg-confirm/input', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', ...authHeaders() },
+                body: JSON.stringify({ jobId: tpgJobId, ...input }),
+            });
+            // Deliberately no error surfaced: the driver applies gestures on its
+            // next tick and the very next frame shows whether it landed, which
+            // is faster feedback than any message could be.
+        } catch { /* the operator can click again */ }
+    };
 
     const cancelTpg = async () => {
         if (!tpgJobId) return;
@@ -1054,40 +1064,25 @@ export const UploadDirectApplicationView: React.FC = () => {
                                 the action — the server cannot open a Singpass browser, so it
                                 hands over to the LMS running on the operator's machine, which
                                 talks to this same database. */}
-                            {!tpgAvailable && (
-                                <p className="text-xs text-amber-700 dark:text-amber-300 mt-2 max-w-xl">
-                                    Singpass needs a person and a visible browser, so this step runs on your
-                                    own computer — not on the server. Start the LMS there and open this page;
-                                    anything you confirm updates this system immediately, because both use the
-                                    same database.
-                                </p>
-                            )}
                         </div>
                     </div>
+                    {/* Same controls everywhere. On the server the browser runs
+                        headless and its screen is streamed into the panel below, so
+                        there is no longer anything the operator must do locally. */}
                     <div className="flex items-end gap-2">
-                        {tpgAvailable ? (
-                            <>
-                                <label className="block">
-                                    <span className="block text-[11px] font-medium text-gray-500 dark:text-gray-400 mb-1">Limit</span>
-                                    <input type="number" min="1" value={tpgMax} onChange={e => setTpgMax(e.target.value)} placeholder="all"
-                                        disabled={tpgRunning}
-                                        className="w-20 px-2 py-1.5 text-sm border border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
-                                </label>
-                                <Button variant="outline" onClick={() => runTpg(true)} disabled={tpgRunning}>Dry run</Button>
-                                <Button onClick={() => runTpg(false)} disabled={tpgRunning}>Confirm &amp; Enrol</Button>
-                                {tpgRunning && (
-                                    <Button variant="outline" onClick={cancelTpg} disabled={tpgCancelling}
-                                        className="!text-red-600 !border-red-300 hover:!bg-red-50 dark:!text-red-300 dark:!border-red-700 dark:hover:!bg-red-900/30">
-                                        {tpgCancelling ? 'Stopping…' : 'Cancel'}
-                                    </Button>
-                                )}
-                            </>
-                        ) : (
-                            <a href={LOCAL_LMS_TPG_URL} target="_blank" rel="noopener noreferrer"
-                                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold rounded-lg bg-purple-600 hover:bg-purple-700 text-white shadow-sm transition-colors">
-                                <Icon name={IconName.Download} className="w-4 h-4" />
-                                Open on my computer
-                            </a>
+                        <label className="block">
+                            <span className="block text-[11px] font-medium text-gray-500 dark:text-gray-400 mb-1">Limit</span>
+                            <input type="number" min="1" value={tpgMax} onChange={e => setTpgMax(e.target.value)} placeholder="all"
+                                disabled={tpgRunning}
+                                className="w-20 px-2 py-1.5 text-sm border border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+                        </label>
+                        <Button variant="outline" onClick={() => runTpg(true)} disabled={tpgRunning}>Dry run</Button>
+                        <Button onClick={() => runTpg(false)} disabled={tpgRunning}>Confirm &amp; Enrol</Button>
+                        {tpgRunning && (
+                            <Button variant="outline" onClick={cancelTpg} disabled={tpgCancelling}
+                                className="!text-red-600 !border-red-300 hover:!bg-red-50 dark:!text-red-300 dark:!border-red-700 dark:hover:!bg-red-900/30">
+                                {tpgCancelling ? 'Stopping…' : 'Cancel'}
+                            </Button>
                         )}
                     </div>
                 </div>
@@ -1148,6 +1143,42 @@ export const UploadDirectApplicationView: React.FC = () => {
                                 ))}
                             </div>
                         </div>
+                        {/* The Singpass step. The run is on the server, so the operator
+                            cannot see its browser — these are live frames of it. Clicking
+                            the picture forwards a click at the same spot on the real page,
+                            which is all this flow needs: a tap or two, then scan the QR. */}
+                        {tpgJob.needsOperator && tpgJob.screen && (
+                            <div className="mt-4 rounded-lg border border-blue-300 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4">
+                                <div className="flex items-start justify-between gap-3 flex-wrap mb-3">
+                                    <div>
+                                        <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                                            Sign in with Singpass to continue
+                                        </p>
+                                        <p className="text-xs text-blue-800 dark:text-blue-300 mt-1 max-w-2xl">
+                                            This is the live browser running on the server. Scan the QR with the
+                                            Singpass app on your phone — you are signing in as yourself. Click the
+                                            picture if you need to press something on the page.
+                                        </p>
+                                    </div>
+                                    <span className="text-[11px] text-blue-700 dark:text-blue-300 tabular-nums">
+                                        updated {new Date(tpgJob.screen.at).toLocaleTimeString([], { hour12: false })}
+                                    </span>
+                                </div>
+                                <img
+                                    src={tpgJob.screen.dataUrl}
+                                    alt="Live view of the sign-in page"
+                                    onClick={(e) => {
+                                        // Map the click from however large the image is rendered
+                                        // back to the page's own coordinate system.
+                                        const r = (e.target as HTMLImageElement).getBoundingClientRect();
+                                        const x = ((e.clientX - r.left) / r.width) * (tpgJob.screen?.width || 1);
+                                        const y = ((e.clientY - r.top) / r.height) * (tpgJob.screen?.height || 1);
+                                        void sendTpgInput({ kind: 'click', x: Math.round(x), y: Math.round(y) });
+                                    }}
+                                    className="w-full rounded border border-blue-200 dark:border-blue-800 cursor-pointer bg-white"
+                                />
+                            </div>
+                        )}
                         {tpgJob.dryRun && !tpgNothingToConfirm && (
                             <p className="text-[11px] mt-1 text-indigo-600 dark:text-indigo-300">Dry run — nothing will be confirmed on TPGateway.</p>
                         )}

--- a/lib/tpg/confirmApplications.ts
+++ b/lib/tpg/confirmApplications.ts
@@ -33,6 +33,7 @@ import {
   approveJob,
   isApproved,
   pushLog,
+  drainInput,
 } from './jobStore';
 
 const REPO_ROOT = process.cwd();
@@ -145,13 +146,21 @@ async function runJob(id: string, opts: StartOptions): Promise<void> {
   try {
     note(id, 'Opening the browser…');
     if (SERVER_BROWSER) {
-      // Shared server: every run starts signed out, so whoever pressed the
-      // button scans the Singpass QR with their own phone and TPGateway sees
-      // that individual. A persistent profile would leave one person's session
-      // behind for the next person's run to inherit — convenient on your own
-      // laptop, wrong on a machine several staff share.
-      browser = await chromium.launch({ headless: false, args: ['--start-maximized'] });
-      context = await browser.newContext({ viewport: null, acceptDownloads: true });
+      // Headless is fine here precisely BECAUSE nobody looks at this browser
+      // directly — the operator watches streamed frames in the LMS and clicks
+      // on them. That is what removes the need to ship a virtual display and a
+      // remote-desktop service on the machine that also hosts the database.
+      //
+      // Fresh context every run, never a persistent profile: each run starts
+      // signed out so whoever pressed the button scans the Singpass QR with
+      // their own phone and TPGateway sees that individual. A shared profile
+      // would hand the next person someone else's session, which the TPGateway
+      // Terms of Use forbid.
+      browser = await chromium.launch({ headless: true });
+      context = await browser.newContext({
+        viewport: { width: SCREEN_W, height: SCREEN_H },
+        acceptDownloads: true,
+      });
     } else {
       // Local operator: keep the profile so you are not re-scanning a QR on
       // every run of your own machine.
@@ -375,18 +384,72 @@ function finishCancelled(id: string, message: string): void {
 
 // --- steps ------------------------------------------------------------------
 
+/** Viewport used for server runs — big enough for the Singpass QR to be legible. */
+const SCREEN_W = 1280;
+const SCREEN_H = 900;
+
+/**
+ * Publish a frame of the page for the panel to render.
+ *
+ * Only used on the server, where there is no window for the operator to look
+ * at. JPEG rather than PNG: these frames go through the status endpoint every
+ * second or so, and a PNG of a full page is several times larger for no benefit
+ * on what is essentially a screenshot of text and a QR code.
+ */
+async function publishScreen(page: Page, jobId: string): Promise<void> {
+  try {
+    const buf = await page.screenshot({ type: 'jpeg', quality: 60 });
+    patchJob(jobId, {
+      screen: {
+        dataUrl: `data:image/jpeg;base64,${buf.toString('base64')}`,
+        width: SCREEN_W,
+        height: SCREEN_H,
+        at: Date.now(),
+      },
+    });
+  } catch {
+    /* mid-navigation — the next tick will get one */
+  }
+}
+
+/** Apply whatever the operator clicked or typed since the last poll. */
+async function applyOperatorInput(page: Page, jobId: string): Promise<void> {
+  for (const input of drainInput(jobId)) {
+    try {
+      if (input.kind === 'click') await page.mouse.click(input.x, input.y);
+      else if (input.kind === 'type') await page.keyboard.type(input.text, { delay: 20 });
+      else if (input.kind === 'key') await page.keyboard.press(input.key);
+    } catch {
+      /* the page moved under the gesture — operator can simply click again */
+    }
+  }
+}
+
 async function waitForLogin(page: Page, timeoutMs: number, jobId: string): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
+  // On the server the operator is watching a stream of frames instead of a real
+  // window, so tell the UI to show it and keep the frames coming.
+  if (SERVER_BROWSER) patchJob(jobId, { needsOperator: true });
   while (Date.now() < deadline) {
     if (isCancelled(jobId)) return false;
+    if (SERVER_BROWSER) {
+      await applyOperatorInput(page, jobId);
+      await publishScreen(page, jobId);
+    }
     try {
       const body = (await page.textContent('body')) || '';
-      if (LOGGED_IN_MARKERS.some((re) => re.test(body))) return true;
+      if (LOGGED_IN_MARKERS.some((re) => re.test(body))) {
+        patchJob(jobId, { needsOperator: false, screen: null });
+        return true;
+      }
     } catch {
       /* mid-navigation — retry */
     }
-    await page.waitForTimeout(2500);
+    // Server runs poll fast so the streamed frames feel live; a local run only
+    // needs to notice that the operator finished in their own window.
+    await page.waitForTimeout(SERVER_BROWSER ? 1000 : 2500);
   }
+  patchJob(jobId, { needsOperator: false });
   return false;
 }
 

--- a/lib/tpg/jobStore.ts
+++ b/lib/tpg/jobStore.ts
@@ -45,6 +45,30 @@ export interface TpgLogEntry {
   text: string;
 }
 
+/**
+ * A live picture of the browser, so a run on the server is still driveable.
+ *
+ * Singpass cannot be automated — someone has to scan a QR with their phone. On
+ * an operator's own machine they just look at the browser window; on the server
+ * there is no window to look at, so the driver posts frames here and the panel
+ * renders them. A picture plus forwarded clicks is enough for this flow and
+ * avoids putting a remote-desktop service on the box that hosts the database.
+ */
+export interface TpgScreen {
+  /** PNG data URL of the current page. */
+  dataUrl: string;
+  /** Rendered size, so the UI can map a click back to page coordinates. */
+  width: number;
+  height: number;
+  at: number;
+}
+
+/** An operator gesture waiting to be applied to the page. */
+export type TpgInput =
+  | { kind: 'click'; x: number; y: number }
+  | { kind: 'type'; text: string }
+  | { kind: 'key'; key: string };
+
 export interface TpgJob {
   id: string;
   dryRun: boolean;
@@ -66,6 +90,12 @@ export interface TpgJob {
    * hung one look identical. These lines are what tells them apart.
    */
   log: TpgLogEntry[];
+  /** Latest browser frame, or null when the run needs no supervision. */
+  screen: TpgScreen | null;
+  /** Gestures the operator has sent that the driver has not applied yet. */
+  pendingInput: TpgInput[];
+  /** True while the driver wants a human looking at `screen`. */
+  needsOperator: boolean;
   /** Parsed Excel rows (header-keyed objects), ready for the UI to ingest. Live mode only. */
   rows: Record<string, unknown>[] | null;
   error: string | null;
@@ -96,6 +126,9 @@ export function createJob(id: string, dryRun: boolean, max: number | null): TpgJ
     approved: false,
     apps: [],
     log: [],
+    screen: null,
+    pendingInput: [],
+    needsOperator: false,
     rows: null,
     error: null,
     screenshot: null,
@@ -143,6 +176,27 @@ export function pushLog(id: string, text: string): void {
     job.log.splice(0, job.log.length - MAX_LOG_LINES);
   }
   job.updatedAt = Date.now();
+}
+
+/** Queue an operator gesture for the driver to apply on its next poll. */
+export function pushInput(id: string, input: TpgInput): boolean {
+  const job = jobs.get(id);
+  if (!job) return false;
+  // Bound the queue: a click-happy operator (or a stuck UI) must not grow this
+  // without limit while the driver is busy between polls.
+  if (job.pendingInput.length >= 50) return false;
+  job.pendingInput.push(input);
+  job.updatedAt = Date.now();
+  return true;
+}
+
+/** Take everything queued, leaving the queue empty. */
+export function drainInput(id: string): TpgInput[] {
+  const job = jobs.get(id);
+  if (!job || job.pendingInput.length === 0) return [];
+  const taken = job.pendingInput;
+  job.pendingInput = [];
+  return taken;
 }
 
 /** Shallow-merge a patch into the job and bump updatedAt. No-op if the job is gone. */

--- a/pages/api/admin/tpg-confirm/input.ts
+++ b/pages/api/admin/tpg-confirm/input.ts
@@ -1,0 +1,76 @@
+/**
+ * POST /api/admin/tpg-confirm/input
+ *
+ * Forwards an operator gesture to the browser a server-side run is driving.
+ * Singpass cannot be automated, so the person who started the run has to reach
+ * the login screen themselves: the panel shows them frames of the page and
+ * sends their clicks and keystrokes here.
+ *
+ * Body: { jobId: string, kind: 'click' | 'type' | 'key', x?, y?, text?, key? }
+ *
+ * Coordinates are in PAGE space — the panel scales them from the rendered
+ * image before sending, so the driver can apply them without knowing how large
+ * the picture was on screen.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { requireRole } from '@lib/auth/requireRole';
+import { pushInput, getJob } from '@lib/tpg/jobStore';
+
+/** Matches the viewport the driver opens for server runs. */
+const MAX_X = 4096;
+const MAX_Y = 4096;
+const MAX_TEXT = 200;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method Not Allowed' });
+  }
+
+  const user = await requireRole(req, res, ['admin', 'developer', 'trainingProvider']);
+  if (!user) return; // requireRole already sent 401/403
+
+  const jobId = typeof req.body?.jobId === 'string' ? req.body.jobId : '';
+  if (!jobId) return res.status(400).json({ success: false, error: 'jobId is required' });
+
+  const job = getJob(jobId);
+  if (!job) return res.status(404).json({ success: false, error: 'Unknown job' });
+
+  // Only accept gestures while the driver is actually asking for a person.
+  // Outside that window the browser is mid-automation and a stray click could
+  // land on a confirmation button.
+  if (!job.needsOperator) {
+    return res.status(409).json({ success: false, error: 'This run is not waiting for input right now.' });
+  }
+
+  const kind = req.body?.kind;
+  let queued = false;
+
+  if (kind === 'click') {
+    const x = Number(req.body?.x);
+    const y = Number(req.body?.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || x < 0 || y < 0 || x > MAX_X || y > MAX_Y) {
+      return res.status(400).json({ success: false, error: 'x and y must be sane page coordinates' });
+    }
+    queued = pushInput(jobId, { kind: 'click', x, y });
+  } else if (kind === 'type') {
+    const text = String(req.body?.text ?? '');
+    if (!text || text.length > MAX_TEXT) {
+      return res.status(400).json({ success: false, error: `text must be 1-${MAX_TEXT} characters` });
+    }
+    queued = pushInput(jobId, { kind: 'type', text });
+  } else if (kind === 'key') {
+    const key = String(req.body?.key ?? '');
+    if (!key || key.length > 20) {
+      return res.status(400).json({ success: false, error: 'key is required' });
+    }
+    queued = pushInput(jobId, { kind: 'key', key });
+  } else {
+    return res.status(400).json({ success: false, error: "kind must be 'click', 'type' or 'key'" });
+  }
+
+  if (!queued) {
+    return res.status(429).json({ success: false, error: 'Too many queued gestures — wait a moment.' });
+  }
+
+  return res.status(200).json({ success: true });
+}


### PR DESCRIPTION
…n-in screen

Staff could only run this from a machine with the LMS installed, because Singpass needs a person looking at a browser. But the operator only has to SEE the QR code to scan it — not drive a desktop. So the server now runs Chromium headless and posts frames of the page into the panel, with clicks forwarded back for the taps before the QR appears.

That removes the alternative of shipping a virtual display and a VNC service on the machine that also hosts the database, and needs no image change at all: Chromium is already installed for brochure rendering.

Each run gets a fresh browser context, so every person signs in as themselves — the TPGateway Terms of Use forbid sharing access to the portal, and a persistent profile would hand the next run someone else's session.

Gestures are only accepted while the driver is actually waiting for a person, so a stray click cannot land on a confirmation button mid-automation.

Verified end to end against the real portal with TPG_SERVER_BROWSER=true: the QR renders in the panel and the Singpass sign-in completes.