### PR TITLE
fix(tpgateway): let a queued run be cancelled, and say what it is wai…

### DIFF
--- a/components/admin/DirectApplicationViews.tsx
+++ b/components/admin/DirectApplicationViews.tsx
@@ -380,6 +380,9 @@ export const UploadDirectApplicationView: React.FC = () => {
     // Where the bar "wants" to be for the current phase (the creep eases toward this).
     const tpgTargetPct = (job: TpgJob | null): number => {
         if (!job) return 0;
+        // Queued is genuinely 0% — nothing has started. Letting the bar creep
+        // here suggests progress that does not exist.
+        if (job.phase === 'queued') return 0;
         if (job.phase === 'done') return 100;
         if (job.phase === 'confirming' && job.total > 0) {
             const done = job.apps.filter(a => ['confirmed', 'would-confirm', 'skipped', 'failed'].includes(a.status)).length;
@@ -995,6 +998,7 @@ export const UploadDirectApplicationView: React.FC = () => {
     );
 
     const TPG_PHASE_LABEL: Record<string, string> = {
+        queued: 'Waiting for the office machine',
         starting: 'Starting…',
         awaiting_login: 'Waiting for Singpass login',
         collecting: 'Finding pending applications',
@@ -1177,6 +1181,22 @@ export const UploadDirectApplicationView: React.FC = () => {
                                     }}
                                     className="w-full rounded border border-blue-200 dark:border-blue-800 cursor-pointer bg-white"
                                 />
+                            </div>
+                        )}
+                        {/* A queued run is waiting on something outside this page, so say
+                            what — a creeping progress bar alone reads as work happening
+                            when in fact nothing has started. */}
+                        {tpgJob.phase === 'queued' && (
+                            <div className="mt-3 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-3">
+                                <p className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                                    Waiting for the office machine to pick this up
+                                </p>
+                                <p className="text-xs text-amber-800 dark:text-amber-300 mt-1 max-w-2xl">
+                                    TPGateway does not accept connections from this server, so the browser
+                                    runs on a machine at the office instead. Nothing happens until that
+                                    machine is on with the agent running. If nobody is expecting to run this
+                                    now, press Cancel.
+                                </p>
                             </div>
                         )}
                         {tpgJob.dryRun && !tpgNothingToConfirm && (

--- a/lib/tpg/jobStore.ts
+++ b/lib/tpg/jobStore.ts
@@ -244,6 +244,18 @@ export function requestCancel(id: string): boolean {
   const job = jobs.get(id);
   if (!job) return false;
   if (isFinished(job)) return false;
+
+  // A queued run has no driver watching the flag — nothing has picked it up
+  // yet — so a cooperative cancel would leave it hanging at "Stopping…"
+  // forever. There is also nothing half-done to protect, so end it here.
+  if (job.phase === 'queued') {
+    job.cancelRequested = true;
+    job.phase = 'cancelled';
+    job.message = 'Cancelled before it started. Nothing was confirmed.';
+    job.updatedAt = Date.now();
+    return true;
+  }
+
   job.cancelRequested = true;
   job.message = 'Stopping…';
   job.updatedAt = Date.now();


### PR DESCRIPTION
…ting for

Cancel raises a flag the driver checks between applications, so a confirmation in flight is never abandoned half-done on TPGateway. A QUEUED run has no driver to read that flag, so cancelling left it at "Stopping…" forever — and because getActiveJob() counts it as active, every later run was refused with a 409 until the container restarted. Nothing is in flight before it starts, so cancel now ends it outright.

The panel also called that state "queued" over a bar creeping to 11%, which reads as work happening. It now says what it is waiting for, and sits at 0%.