### PR TITLE
fix(wsq-sync): build sessions from the storefront label, and resolve …

### DIFF
--- a/components/admin/WsqScheduleSyncView.tsx
+++ b/components/admin/WsqScheduleSyncView.tsx
@@ -267,7 +267,11 @@ const stopPolling = useCallback(() => {
   const expandAll = () => setExpanded(new Set(filtered.map((g) => g.course_code)));
   const collapseAll = () => setExpanded(new Set());
 
-  const syncToSSG = async (items: { course_code: string; start_date: string; end_date: string }[], label: string) => {
+  // `raw` is the storefront's own label for the run ("1/4 Jan 2027 (Fri/Mon)").
+  // It is the ONLY thing that states the individual teaching days — start and end
+  // alone read as a consecutive range, so a Fri/Mon class becomes Fri/Sat. Pass it
+  // through; run-sync builds the sessions from it.
+  const syncToSSG = async (items: { course_code: string; start_date: string; end_date: string; raw?: string }[], label: string) => {
     // Only sync/retry past-dated classes when "Show past classes" is on. This gates
     // Retry-All + per-course + per-row retries at the action level — a safety net in
     // case stale (past-included) data is briefly present during a toggle reload.
@@ -387,7 +391,7 @@ const stopPolling = useCallback(() => {
     const items = filtered.flatMap((g) =>
       g.rows
         .filter((r) => r.start_date && r.end_date)
-        .map((r) => ({ course_code: g.course_code, start_date: r.start_date!, end_date: r.end_date! })),
+        .map((r) => ({ course_code: g.course_code, start_date: r.start_date!, end_date: r.end_date!, raw: r.raw })),
     );
     void syncToSSG(items, 'all courses, current filter');
   };
@@ -395,14 +399,14 @@ const stopPolling = useCallback(() => {
   const syncCourse = (g: CourseGroup) => {
     const items = g.rows
       .filter((r) => r.start_date && r.end_date)
-      .map((r) => ({ course_code: g.course_code, start_date: r.start_date!, end_date: r.end_date! }));
+      .map((r) => ({ course_code: g.course_code, start_date: r.start_date!, end_date: r.end_date!, raw: r.raw }));
     void syncToSSG(items, g.course_code);
   };
 
   const syncRow = (group: CourseGroup, row: Row) => {
     if (!row.start_date || !row.end_date) return;
     void syncToSSG(
-      [{ course_code: group.course_code, start_date: row.start_date, end_date: row.end_date }],
+      [{ course_code: group.course_code, start_date: row.start_date, end_date: row.end_date, raw: row.raw }],
       `${group.course_code} ${row.start_date}`,
     );
   };

--- a/lib/wsqScheduleSync.ts
+++ b/lib/wsqScheduleSync.ts
@@ -9,7 +9,10 @@ export type MagentoSchedule = { raw?: string; course_start_date: string | null; 
 export type MagentoCourse = { course_code: string; course_title?: string; schedules: MagentoSchedule[] };
 export type MagentoResponse = { courses: MagentoCourse[]; generated_at?: string; count?: number; store?: string };
 
-export type SyncItem = { course_code: string; start_date: string; end_date: string };
+// `raw` is the storefront's human label ("5/12/13/19/26 Sep 2026 (Sat/Sun)").
+// It is the only source that states the individual teaching days — start/end
+// alone cannot express a run taught on five scattered Saturdays.
+export type SyncItem = { course_code: string; start_date: string; end_date: string; raw?: string };
 
 /** Current date (YYYY-MM-DD) in Asia/Singapore — the single "today" for UI + crons. */
 export function sgtToday(): string {
@@ -61,7 +64,7 @@ export function futureScheduleItems(magento: MagentoResponse, today: string): Sy
       if (!start || !end) continue;      // unparsed
       if (end < today) continue;          // already ended
       if (start < today) continue;        // already started (SSG rejects past start)
-      items.push({ course_code: code, start_date: start, end_date: end });
+      items.push({ course_code: code, start_date: start, end_date: end, raw: s.raw });
     }
   }
   return items;

--- a/pages/api/admin/wsq-schedule-sync/run-sync.ts
+++ b/pages/api/admin/wsq-schedule-sync/run-sync.ts
@@ -19,7 +19,7 @@ import { COURSE_ID_BY_ANY_CODE_SQL } from '../../../../lib/courseCode';
  * missing, re-running after a partial failure naturally skips already-done items.
  */
 
-type SubmitItem = { course_code: string; start_date: string; end_date: string };
+type SubmitItem = { course_code: string; start_date: string; end_date: string; raw?: string };
 type ItemResult = {
   course_code: string; start_date: string; end_date: string;
   status: 'submitted' | 'exists' | 'no_course' | 'no_session_timing' | 'ssg_error' | 'error';
@@ -48,28 +48,330 @@ const addDays = (dateStr: string, n: number): string => {
   return d.toISOString().split('T')[0];
 };
 
-const buildSessions = (timing: Record<string, any>, startDate: string, endDate: string) => {
-  const isOneDay = startDate === endDate;
-  const sessions: { startDate: string; endDate: string; startTime: string; endTime: string; modeOfTraining: string }[] = [];
-  let currentDate = startDate;
-  let prevEndTime = '';
-  for (let i = 1; i <= 11; i++) {
-    const startTime = (timing[`session_${i}_start_time`] || '').trim();
-    const endTime   = (timing[`session_${i}_end_time`]   || '').trim();
-    if (!startTime && !endTime) break;
-    const mode = normalizeModeOfTraining(timing[`session_${i}_mode_of_training`]);
-    let date = startDate;
-    if (!isOneDay) {
-      if (prevEndTime && startTime && startTime < prevEndTime) {
-        const next = addDays(currentDate, 1);
-        currentDate = endDate && next > endDate ? endDate : next;
-      }
-      date = currentDate;
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+/**
+ * The exact teaching dates, read from the storefront's own human-readable label.
+ *
+ * start/end alone cannot express a scattered run: "5/12/13/19/26 Sep 2026" spans
+ * 22 days but is taught on five Saturdays and Sundays. The label spells every day
+ * out, so parse it rather than interpolating between the endpoints.
+ *
+ * Handles the 22 label shapes the storefront actually produces, e.g.
+ *   16/17 Oct 2026 (Fri/Sat)              two days, one month
+ *   5/12/13/19/26 Sep 2026 (Sat/Sun)      scattered, one month
+ *   30 Oct / 2 Nov 2026 (Fri/Mon)         split across months
+ *   28 Dec 2026 - 1 Jan 2027 (Mon-Fri)    consecutive across years
+ *   26-30 Oct 2026 (Mon-Fri)              consecutive
+ *   01 Sep 2026 (Tue)                     single day
+ *
+ * The trailing "(Sat/Sun)" is day NAMES, not dates — dropped before parsing, or
+ * a five-day run reads as seven. Months and years propagate right-to-left, since
+ * "5/12/13 Sep 2026" states them only once at the end.
+ *
+ * Returns null when the label cannot be read confidently; the caller then falls
+ * back to deriving dates from start/end.
+ */
+const parseRawDates = (raw: string): string[] | null => {
+  if (!raw) return null;
+  const cleaned = raw
+    .replace(/\([^)]*\)/g, ' ')      // "(Sat/Sun)" — day names, not dates
+    .replace(/\bevening\b/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return null;
+
+  const isRange = !cleaned.includes('/') && cleaned.includes('-');
+  const parts = cleaned.split(isRange ? '-' : '/').map((p) => p.trim()).filter(Boolean);
+  if (parts.length === 0 || parts.length > 12) return null;
+
+  // Right-to-left: a bare "5" inherits the month and year stated later in the label.
+  let month = 0;
+  let year = 0;
+  const dates: string[] = [];
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const m = parts[i].match(/^(\d{1,2})\s*([A-Za-z]{3,9})?\.?\s*(\d{4})?$/);
+    if (!m) return null;
+    const day = Number(m[1]);
+    if (m[3]) year = Number(m[3]);
+    if (m[2]) {
+      const mm = MONTHS[m[2].slice(0, 3).toLowerCase()];
+      if (!mm) return null;
+      month = mm;
     }
-    prevEndTime = endTime;
-    sessions.push({ startDate: date, endDate: date, startTime, endTime, modeOfTraining: mode });
+    if (!day || !month || !year) return null;
+    dates.unshift(`${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`);
   }
-  return sessions;
+
+  if (isRange) {
+    // "26-30 Oct" / "28 Dec 2026 - 1 Jan 2027" — every day between, inclusive.
+    if (dates.length !== 2) return null;
+    const out: string[] = [];
+    for (let d = dates[0]; d <= dates[1]; d = addDays(d, 1)) {
+      out.push(d);
+      if (out.length > 40) return null;
+    }
+    return out;
+  }
+
+  // A slash list must be ascending; anything else means we misread it.
+  for (let i = 1; i < dates.length; i++) if (dates[i] <= dates[i - 1]) return null;
+  return dates;
+};
+
+/** Whole days from a to b, both YYYY-MM-DD. */
+const daysBetween = (a: string, b: string): number =>
+  Math.round((Date.parse(b + 'T00:00:00Z') - Date.parse(a + 'T00:00:00Z')) / 86400000);
+
+/**
+ * Which calendar dates the template's teaching days land on.
+ *
+ * A class is NOT always run on consecutive days: the storefront sells plenty of
+ * "1/4 Jan 2027 Fri/Mon" style runs, where the two teaching days sit either side
+ * of a weekend. Counting forward one day per teaching day put day two on the
+ * Saturday — verified 26 Aug 2026 on a real submission, where TPGateway showed
+ * sessions on 1 and 2 Jan with the advertised 4 Jan empty. Attendance is taken
+ * per session, so those learners would have had nothing to register against on
+ * the day they actually attended.
+ *
+ * The storefront already tells us the real teaching days: it gives the run's
+ * start AND end. So anchor to those rather than counting.
+ */
+const teachingDates = (dayCount: number, startDate: string, endDate: string): string[] => {
+  if (dayCount <= 1) return [startDate];
+  const span = daysBetween(startDate, endDate) + 1;
+  // Consecutive run (16-17 Jan): every day between start and end is a teaching day.
+  if (span === dayCount) {
+    return Array.from({ length: dayCount }, (_, i) => addDays(startDate, i));
+  }
+  // Split run (1 Jan / 4 Jan): first and last are the dates actually sold. Any
+  // middle days are unknowable from start+end alone, so they follow the start.
+  // Never invent more distinct days than the run actually spans — padding to
+  // reach dayCount repeats the end date, which then reads as "enough days" while
+  // silently stacking two teaching days onto one. Return what the span allows and
+  // let the caller report the shortfall.
+  const usableDays = Math.min(dayCount, span);
+  if (usableDays === span) {
+    return Array.from({ length: usableDays }, (_, i) => addDays(startDate, i));
+  }
+  const out = [startDate];
+  for (let i = 1; i < usableDays - 1; i++) out.push(addDays(startDate, i));
+  out.push(endDate);
+  return out;
+};
+
+type BuiltSession = { startDate: string; endDate: string; startTime: string; endTime: string; modeOfTraining: string };
+type SessionMismatch = { mismatch: { templateDays: number; runDays: number } };
+
+type PastPattern = { day: number; startTime: string; endTime: string; modeOfTraining: string }[];
+
+/** A run is "evening" when its first session starts at or after 17:00. */
+const EVENING_FROM = '17:00';
+
+/**
+ * The session pattern this course last actually ran, as accepted by SSG.
+ *
+ * Preferred over course_session_timing because a course carries only ONE
+ * template and is frequently sold in TWO shapes. Lean Six Sigma runs as one full
+ * day (09:15-13:15, 14:00-17:00, 17:00-18:00 assessment) AND as two evenings
+ * (18:00-22:00, then 18:00-21:00 + 21:00-22:00 assessment) — the template
+ * describes only the first, so building an evening run from it starts the class
+ * at quarter past nine in the morning.
+ *
+ * Matched on shape, not just recency: same number of teaching days, and evening
+ * only clones from evening. Measured 27 Aug 2026 — every one of the 63 evening
+ * runs on record starts at 18:00, and night one is always 18:00-22:00; only the
+ * night-two split varies by course, which is exactly why it is cloned per course
+ * rather than derived from a rule.
+ */
+async function pastSessionPattern(
+  courseId: string,
+  teachingDays: number,
+  wantEvening: boolean,
+): Promise<PastPattern | null> {
+  const rows = (await pool.query<{ start_date: string; start_time: string; end_time: string; mode_of_training: string }>(
+    `WITH candidate AS (
+        SELECT cr.id, max(cr.start_date) AS started
+          FROM course_run cr
+          JOIN course_session s ON s.course_run_id = cr.id AND COALESCE(s.deleted, false) = false
+         WHERE cr.course_id = $1
+           AND COALESCE(cr.is_deleted, false) = false
+         GROUP BY cr.id
+        HAVING count(DISTINCT s.start_date) = $2
+           AND (min(s.start_time) >= $3) = $4
+         ORDER BY started DESC
+         LIMIT 1)
+      SELECT s.start_date, s.start_time, s.end_time, s.mode_of_training
+        FROM candidate cnd
+        JOIN course_session s ON s.course_run_id = cnd.id AND COALESCE(s.deleted, false) = false
+       ORDER BY s.start_date, s.start_time`,
+    [courseId, teachingDays, EVENING_FROM, wantEvening],
+  ).catch(() => ({ rows: [] as any[] }))).rows;
+  if (rows.length === 0) return null;
+
+  // Collapse the past run's own dates into day indexes, so the pattern can be
+  // laid onto whatever dates the new run uses.
+  const dayIndex = new Map<string, number>();
+  for (const r of rows) if (!dayIndex.has(r.start_date)) dayIndex.set(r.start_date, dayIndex.size);
+  return rows.map((r) => ({
+    day: dayIndex.get(r.start_date)!,
+    startTime: (r.start_time || '').trim(),
+    endTime: (r.end_time || '').trim(),
+    modeOfTraining: normalizeModeOfTraining(r.mode_of_training),
+  }));
+}
+
+const EVENING_START_MIN = 18 * 60;   // every one of the 63 evening runs on record starts at 18:00
+const EVENING_LENGTH_MIN = 4 * 60;   // and night one is always 18:00-22:00
+// Hard bound on how late a derived evening may run. Without it the final night
+// absorbs whatever will not fit: a 16-hour course over two evenings derives a
+// night ending at 30:00 — six in the morning. 553 templates do this. 23:00 leaves
+// room for the genuine 20:45-22:15 assessment slot seen in real runs while
+// refusing anything that is plainly not a class.
+const EVENING_LATEST_END_MIN = 23 * 60;
+
+const toMinutes = (t: string): number => {
+  const [h, m] = t.split(':').map(Number);
+  return (h || 0) * 60 + (m || 0);
+};
+const toClock = (m: number): string =>
+  `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+
+/**
+ * An evening pattern derived from the course's daytime template.
+ *
+ * Used only when a course is sold as an evening class but has never run one, so
+ * there is nothing to clone. Rather than invent times, repack the daytime
+ * template's session LENGTHS, in order, into evenings from 18:00, four hours a
+ * night — which is demonstrably the rule the schedulers already follow.
+ *
+ * Verified 27 Aug 2026 against every evening course with history, and it
+ * reproduces each exactly, including the two different night-two splits:
+ *   09:15-13:15 / 14:00-17:00 / 17:00-18:00
+ *     -> 18:00-22:00 | 18:00-21:00 + 21:00-22:00   (Lean Six Sigma, Interviewing)
+ *   09:15-13:15 / 14:00-16:30 / 16:30-18:00
+ *     -> 18:00-22:00 | 18:00-20:30 + 20:30-22:00   (Lightroom, AI for eCommerce)
+ *
+ * Session order, lengths and modes are preserved, so the assessment stays last
+ * and keeps its own slot.
+ */
+const deriveEveningPattern = (
+  slots: { startTime: string; endTime: string; modeOfTraining: string }[],
+  nights: number,
+): PastPattern => {
+  const out: PastPattern = [];
+  let night = 0;
+  let cursor = EVENING_START_MIN;
+  for (const sl of slots) {
+    const length = toMinutes(sl.endTime) - toMinutes(sl.startTime);
+    if (length <= 0) return [];
+    if (cursor + length > EVENING_START_MIN + EVENING_LENGTH_MIN && night < nights - 1) {
+      night++;
+      cursor = EVENING_START_MIN;
+    }
+    if (cursor + length > EVENING_LATEST_END_MIN) return [];
+    out.push({
+      day: night,
+      startTime: toClock(cursor),
+      endTime: toClock(cursor + length),
+      modeOfTraining: sl.modeOfTraining,
+    });
+    cursor += length;
+  }
+  return out;
+};
+
+const buildSessions = (
+  timing: Record<string, any>,
+  startDate: string,
+  endDate: string,
+  raw?: string,
+  pattern?: PastPattern | null,
+): BuiltSession[] | SessionMismatch => {
+  type Slot = { day: number; startTime: string; endTime: string; modeOfTraining: string };
+
+  // Pass 1 — the slots, and which teaching DAY each one falls on.
+  // A cloned pattern already carries its day indexes; a template does not, so
+  // there a slot starting earlier than the previous one ended marks a new day.
+  let slots: Slot[];
+  let day = 0;
+  if (pattern && pattern.length > 0) {
+    slots = pattern;
+    day = Math.max(...pattern.map((p) => p.day));
+  } else {
+    slots = [];
+    let prevEndTime = '';
+    for (let i = 1; i <= 11; i++) {
+      const startTime = (timing[`session_${i}_start_time`] || '').trim();
+      const endTime   = (timing[`session_${i}_end_time`]   || '').trim();
+      if (!startTime && !endTime) break;
+      if (prevEndTime && startTime && startTime < prevEndTime) day++;
+      prevEndTime = endTime;
+      slots.push({
+        day,
+        startTime,
+        endTime,
+        modeOfTraining: normalizeModeOfTraining(timing[`session_${i}_mode_of_training`]),
+      });
+    }
+  }
+  if (slots.length === 0) return [];
+
+  // Pass 2 — put those days on the dates the storefront actually sells.
+  // Prefer the storefront's own label, but only when it agrees with the start and
+  // end dates we were given: those come from structured fields and are the thing
+  // SSG will hold the run against. A label that disagrees has been misread, and
+  // guessing wrong here puts a class on a day nobody attends.
+  const dayCount = day + 1;
+  const parsed = parseRawDates(raw ?? '');
+  const anchored = parsed
+    && parsed[0] === startDate
+    && parsed[parsed.length - 1] === endDate;
+
+  // The template and the storefront must agree on how many days the class runs.
+  // They disagree in both directions, and neither can be papered over:
+  //
+  //   template needs MORE days than the run offers — the extra days clamp onto
+  //     the last date, giving two 09:15 starts and three overlapping afternoons.
+  //     SSG replies "Session seqNo #5 is overlapping with seqNo #7", which is
+  //     true and unactionable. Seen on TGS-2024045221 "2-4 Oct 2026 (Fri-Mon)",
+  //     where Friday to Monday is four days but the dates say three.
+  //
+  //   run offers MORE days than the template covers — measured 27 Aug 2026, 177
+  //     runs. Lean Six Sigma is sold both as one full day and as two evenings,
+  //     but a course carries only ONE timing template and it describes the full
+  //     day. Building the evening run from it puts a 09:15 session on an evening
+  //     class and leaves the second night with no session to take attendance
+  //     against. Wrong times are worse than a refusal.
+  //
+  // Either way the honest answer is that this run cannot be built from the
+  // template we have, and someone needs to add the missing one.
+  if (anchored && (parsed as string[]).length !== dayCount) {
+    return { mismatch: { templateDays: dayCount, runDays: (parsed as string[]).length } };
+  }
+
+  const usable = anchored && (parsed as string[]).length === dayCount;
+  const dates = usable ? (parsed as string[]) : teachingDates(dayCount, startDate, endDate);
+
+  // Without a readable label we fall back to start/end, which cannot always
+  // supply enough distinct days either.
+  if (dates.length < dayCount) {
+    return { mismatch: { templateDays: dayCount, runDays: dates.length } };
+  }
+
+  return slots.map((sl) => {
+    const date = dates[sl.day];
+    return {
+      startDate: date,
+      endDate: date,
+      startTime: sl.startTime,
+      endTime: sl.endTime,
+      modeOfTraining: sl.modeOfTraining,
+    };
+  });
 };
 
 const VENUE = { floor: '07', unit: '85-87', postalCode: '737715', room: 'Training room' };
@@ -127,10 +429,85 @@ async function processItem(
       LIMIT 1`,
     [course_code, courseId],
   ).catch(() => ({ rows: [] as Record<string, any>[] }));
-  if (!timingRow.rows[0]) {
-    return { course_code, start_date, end_date, status: 'no_session_timing', message: 'No session timing template found' };
+  // A missing template is NOT fatal on its own. Cloning the course's own last run
+  // is the preferred source of session times and needs no template at all, so the
+  // "no timing" verdict is deferred until that has been tried too — bailing here
+  // refused courses with a full history of real sessions purely because a form had
+  // never been filled in.
+  const timing = timingRow.rows[0] ?? null;
+
+  // How many days is this run taught over, and is it an evening class? Both come
+  // from the storefront label; the dates are the fallback when it cannot be read.
+  const wantEvening = /\bevening\b/i.test(item.raw ?? '');
+  const labelDates = parseRawDates(item.raw ?? '');
+  const teachingDays = labelDates
+    && labelDates[0] === start_date
+    && labelDates[labelDates.length - 1] === end_date
+      ? labelDates.length
+      : null;
+
+  // Clone the shape this course last actually ran, matched on day count and
+  // day/evening. Falls back to the template only for daytime runs — the template
+  // IS the daytime pattern, so using it for an evening class would put a 09:15
+  // session on a class that starts at 18:00.
+  const pattern = teachingDays
+    ? await pastSessionPattern(courseId, teachingDays, wantEvening)
+    : null;
+
+  // Now both sources have been tried: nothing to clone and nothing to build from.
+  if (!timing && !pattern) {
+    return { course_code, start_date, end_date, status: 'no_session_timing',
+      message: 'No session timing template found, and this course has no past run of the same shape to copy' };
   }
-  const sessions = buildSessions(timingRow.rows[0], start_date, end_date);
+
+  // No evening history for this course — derive the pattern from its daytime
+  // template instead of refusing. Cloning real history is still preferred; this
+  // only fills the gap for a course running its first evening class.
+  let effectivePattern = pattern;
+  // Deriving repacks the DAYTIME template's session lengths into evenings, so it
+  // needs a template — a course with neither template nor evening history cannot
+  // be derived and falls through to the refusal below.
+  if (wantEvening && !effectivePattern && teachingDays && timing) {
+    const daySlots: { startTime: string; endTime: string; modeOfTraining: string }[] = [];
+    for (let i = 1; i <= 11; i++) {
+      const st = (timing[`session_${i}_start_time`] || '').trim();
+      const en = (timing[`session_${i}_end_time`] || '').trim();
+      if (!st && !en) break;
+      daySlots.push({
+        startTime: st,
+        endTime: en,
+        modeOfTraining: normalizeModeOfTraining(timing[`session_${i}_mode_of_training`]),
+      });
+    }
+    const derived = deriveEveningPattern(daySlots, teachingDays);
+    if (derived.length > 0) effectivePattern = derived;
+  }
+
+  if (wantEvening && !effectivePattern) {
+    return {
+      course_code, start_date, end_date, status: 'no_session_timing',
+      message:
+        `This run is sold as an evening class (${item.raw}) but this course has no ` +
+        `evening history to clone, and its daytime timings do not fit into evening ` +
+        `sessions — the course is too long for the number of evenings offered. ` +
+        `Create one evening run by hand so the rest can be cloned from it.`,
+    };
+  }
+
+  const built = buildSessions(timing ?? {}, start_date, end_date, item.raw, effectivePattern);
+  if ('mismatch' in built) {
+    const { templateDays, runDays } = built.mismatch;
+    const when = item.raw || `${start_date} to ${end_date}`;
+    return {
+      course_code, start_date, end_date, status: 'no_session_timing',
+      message: runDays < templateDays
+        ? `The session timing template covers ${templateDays} day(s) but this run only offers ${runDays} (${when}). ` +
+          `The dates on the storefront look wrong.`
+        : `This run is sold over ${runDays} day(s) but the session timing template only covers ${templateDays} (${when}). ` +
+          `This format needs its own timing template — building it from the existing one would put the class at the wrong time of day.`,
+    };
+  }
+  const sessions = built;
   if (!sessions.length) {
     return { course_code, start_date, end_date, status: 'no_session_timing', message: 'Session timing template has no sessions' };
   }

--- a/pages/api/external/wsq-schedule-gap.ts
+++ b/pages/api/external/wsq-schedule-gap.ts
@@ -109,7 +109,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               c.title,
               c.course_type::text AS course_type,
               to_char(c.ssg_wsq_support_to, 'YYYY-MM-DD') AS funding_to,
-              EXISTS (SELECT 1 FROM course_session_timing t WHERE t.course_code = c.course_code) AS has_timing
+              -- Mirror run-sync's own timing lookup, or this report contradicts the
+              -- thing it is reporting on. Two reasons a literal match is too strict:
+              --   1. Funding renewal issues a NEW course reference number and the
+              --      storefront switches to it at once, but the template stays filed
+              --      under whichever code it was created with — measured 26 Aug 2026,
+              --      all 36 renewed courses had theirs under the OLD code.
+              --   2. run-sync no longer requires a template at all: it prefers cloning
+              --      the course's own last run of the same shape, which needs none.
+              -- Reporting either case as "no_session_timing" hides work that would in
+              -- fact submit cleanly.
+              (EXISTS (SELECT 1 FROM course_session_timing t
+                        WHERE t.course_code = c.course_code
+                           OR t.course_code IN (SELECT h.code FROM course_code_history h
+                                                 WHERE h.course_id = c.id))
+               OR EXISTS (SELECT 1 FROM course_run cr
+                            JOIN course_session ss ON ss.course_run_id = cr.id
+                                                  AND COALESCE(ss.deleted, false) = false
+                           WHERE cr.course_id = c.id
+                             AND COALESCE(cr.is_deleted, false) = false)) AS has_timing
          FROM course c
         WHERE c.course_code LIKE 'TGS-%'`,
     )).rows;

--- a/pages/api/external/wsq-submit-runs.ts
+++ b/pages/api/external/wsq-submit-runs.ts
@@ -59,7 +59,12 @@ import { createSSGCourseAPI } from '../../../lib/ssg/api/course-api';
 
 const MAX_ITEMS = 250;
 
-type Item = { course_code: string; start_date: string; end_date: string };
+// `raw` is the storefront's own label for the run ("5/12/13/19/26 Sep 2026
+// (Sat/Sun)"). It is the ONLY thing that states the individual teaching days —
+// start and end alone cannot express a run taught on five scattered Saturdays —
+// and run-sync reads it when building sessions. Dropping it here would silently
+// put three of that run's five classes on days nobody attends.
+type Item = { course_code: string; start_date: string; end_date: string; raw?: string };
 type Rejected = Item & { reason: string };
 
 const isDate = (s: unknown) => /^\d{4}-\d{2}-\d{2}$/.test(String(s ?? ''));
@@ -143,34 +148,42 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         error: `Could not read the storefront schedule: ${e instanceof Error ? e.message : String(e)}`,
       });
     }
-    const soldDates = new Map<string, Set<string>>();
+    // date-pair -> the label describing it, so an explicit items[] request can
+    // recover the label the caller had no way of supplying.
+    const soldDates = new Map<string, Map<string, string>>();
     for (const m of magento.courses || []) {
       const code = (m.course_code ?? '').trim();
       if (!code) continue;
-      const set = soldDates.get(code) ?? new Set<string>();
+      const byDates = soldDates.get(code) ?? new Map<string, string>();
       for (const s of m.schedules || []) {
         const st = s.course_start_date?.slice(0, 10);
         const en = s.course_end_date?.slice(0, 10);
-        if (st && en) set.add(`${st}|${en}`);
+        if (st && en) byDates.set(`${st}|${en}`, String(s.raw ?? ''));
       }
-      soldDates.set(code, set);
+      soldDates.set(code, byDates);
     }
 
     // ── Build the candidate list ──────────────────────────────────────────────
     let candidates: Item[];
     if (rawItems.length > 0) {
-      candidates = rawItems.map((i) => ({
-        course_code: String(i?.course_code ?? '').trim(),
-        start_date: String(i?.start_date ?? '').trim(),
-        end_date: String(i?.end_date ?? '').trim(),
-      }));
+      candidates = rawItems.map((i) => {
+        const course_code = String(i?.course_code ?? '').trim();
+        const start_date = String(i?.start_date ?? '').trim();
+        const end_date = String(i?.end_date ?? '').trim();
+        return {
+          course_code,
+          start_date,
+          end_date,
+          raw: soldDates.get(course_code)?.get(`${start_date}|${end_date}`),
+        };
+      });
     } else {
       candidates = [];
-      for (const [code, dates] of soldDates.entries()) {
+      for (const [code, byDates] of soldDates.entries()) {
         if (code.toUpperCase() !== onlyCourse) continue;
-        for (const d of dates) {
+        for (const [d, raw] of byDates.entries()) {
           const [start_date, end_date] = d.split('|');
-          candidates.push({ course_code: code, start_date, end_date });
+          candidates.push({ course_code: code, start_date, end_date, raw });
         }
       }
       if (candidates.length === 0) {
@@ -198,6 +211,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!soldDates.get(it.course_code)?.has(`${it.start_date}|${it.end_date}`)) {
         reject('not sold on the storefront for these exact dates'); continue;
       }
+      // Prefer the storefront's label over anything the caller supplied.
+      it.raw = soldDates.get(it.course_code)!.get(`${it.start_date}|${it.end_date}`) || it.raw;
 
       const canonical = canonicalByAlias.get(it.course_code) ?? it.course_code;
       const course = courses.get(canonical);


### PR DESCRIPTION
…timings through renewed course codes